### PR TITLE
fix: release workflow, error handling, mac arm, listen_wallet

### DIFF
--- a/.github/workflows/bindings-native-publish.yml
+++ b/.github/workflows/bindings-native-publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-20.04, windows-2022]
+        os: [macos-13, macos-13-arm, ubuntu-20.04, windows-2022]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-arm'
         with:
           xcode-version: '14.3'
 
@@ -47,11 +47,11 @@ jobs:
 
       - name: Set deployment target (macOS)
         run: echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-arm'
 
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-        if: matrix.os == 'macos-13' || ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-arm' || ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Get current date
         if: matrix.os == 'windows-2022'

--- a/.github/workflows/bindings-native-publish.yml
+++ b/.github/workflows/bindings-native-publish.yml
@@ -94,6 +94,14 @@ jobs:
 
       - name: Cargo build
         run: cargo build --release        
+
+      - name: Rename file (MacOS/arm64)
+        run: mv target/release/libiota_sdk.dylib target/release/libiota_sdk_arm64.dylib
+        if: matrix.os == 'macos-13-xlarge'
+
+      - name: Rename file (MacOS/amd64)
+        run: mv target/release/libiota_sdk.dylib target/release/libiota_sdk_amd64.dylib
+        if: matrix.os == 'macos-13'
           
       - name: Upload package to Github release
         uses: softprops/action-gh-release@v1
@@ -102,6 +110,8 @@ jobs:
           files: | 
             target/release/libiota_sdk.so
             target/release/iota_sdk.dll
-            target/release/libiota_sdk.dylib
+            target/release/libiota_sdk_arm64.dylib
+            target/release/libiota_sdk_amd64.dylib
+
           fail_on_unmatched_files: false
           tag_name: ${{ steps.prepare_release.outputs.tag_name }}

--- a/.github/workflows/bindings-native-publish.yml
+++ b/.github/workflows/bindings-native-publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-13-arm, ubuntu-20.04, windows-2022]
+        os: [macos-13, macos-13-xlarge, ubuntu-20.04, windows-2022]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-arm'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-xlarge'
         with:
           xcode-version: '14.3'
 
@@ -47,11 +47,11 @@ jobs:
 
       - name: Set deployment target (macOS)
         run: echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-arm'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-xlarge'
 
       - name: Get current date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-arm' || ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-13-xlarge' || ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Get current date
         if: matrix.os == 'windows-2022'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-sdk-native-bindings"
-version = "0.1.0"
+version = "0.1.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Native wrapper for the IOTA SDK library"
@@ -22,7 +22,7 @@ default = ["std"]
 std = ["zeroize/std"]
 
 [dependencies]
-iota-sdk-bindings-core = { git = "https://github.com/iotaledger/iota-sdk.git", rev = "8f57f0c50f555b5e62f78ebf0177fc71b78f0396", default-features = false, features = [ 
+iota-sdk-bindings-core = { git = "https://github.com/iotaledger/iota-sdk.git", branch = "develop", default-features = false, features = [
     "events", 
     "rocksdb", 
     "ledger_nano", 


### PR DESCRIPTION
Fixes `listen_wallet`
Fixes error handling
Fixes in the release workflow
Points `iota-sdk` dependency to `develop` instead of a commit hash
Enables Mac OS ARM(m1/m2) variants
